### PR TITLE
Enables 2.0 to work with Lumen

### DIFF
--- a/src/Wpb/StringBladeCompiler/StringView.php
+++ b/src/Wpb/StringBladeCompiler/StringView.php
@@ -8,12 +8,11 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\View\Engines\CompilerEngine;
 use StringCompilerException;
-use View;
+use \Illuminate\View\View as View;
 use Wpb\StringBladeCompiler\Compilers\StringBladeCompiler;
 
 
-class StringView extends \Illuminate\View\View implements ArrayAccess, ViewContract
-{
+class StringView extends \Illuminate\View\View implements ArrayAccess, ViewContract {
 
     protected $template_field = 'template';
     protected $compiler;
@@ -21,7 +20,7 @@ class StringView extends \Illuminate\View\View implements ArrayAccess, ViewContr
 
     public function __construct()
     {
-        $cache = App::make('path.storage') . '/framework/views';
+        $cache = storage_path('framework/views');
         $this->compiler = new StringBladeCompiler(App::make('files'), $cache);
 
         $this->engine = new CompilerEngine($this->compiler);
@@ -273,7 +272,7 @@ class StringView extends \Illuminate\View\View implements ArrayAccess, ViewContr
     {
         $this->engine->getCompiler()->setContentTags($openTag, $closeTag, $escaped);
     }
-    
+
     /**
      * Set the echo format to be used by the compiler.
      *

--- a/src/Wpb/StringBladeCompiler/StringView.php
+++ b/src/Wpb/StringBladeCompiler/StringView.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\View\Engines\CompilerEngine;
 use StringCompilerException;
-use \Illuminate\View\View as View;
+use Illuminate\View\View as View;
 use Wpb\StringBladeCompiler\Compilers\StringBladeCompiler;
 
 

--- a/src/Wpb/StringBladeCompiler/StringView.php
+++ b/src/Wpb/StringBladeCompiler/StringView.php
@@ -6,9 +6,9 @@ use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Support\Facades\View;
 use Illuminate\View\Engines\CompilerEngine;
 use StringCompilerException;
-use Illuminate\View\View as View;
 use Wpb\StringBladeCompiler\Compilers\StringBladeCompiler;
 
 


### PR DESCRIPTION
I found that Lumen wasn't playing nice as the `View` facade was not being loaded with the `use View` call, but with `use Illuminate\Support\Facades\View;` it works. Also `App::make('path.storage')` does not work with Lumen, but `storage_path()` does.