### PR TITLE
Laravel 5.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-	"laravel/framework": "5.3.*"
+	"laravel/framework": "5.4.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -964,6 +964,31 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Flush all of the factory state like sections and stacks.
+     *
+     * @return void
+     */
+    public function flushState()
+    {
+        $this->renderCount = 0;
+
+        $this->flushSections();
+        $this->flushStacks();
+    }
+
+    /**
+     * Flush all of the section contents if done rendering.
+     *
+     * @return void
+     */
+    public function flushStateIfDoneRendering()
+    {
+        if ($this->doneRendering()) {
+            $this->flushState();
+        }
+    }
+
+    /**
      * Get the extension to engine bindings.
      *
      * @return array

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,23 +2,26 @@
 
 namespace Wpb\String_Blade_Compiler;
 
-use Closure;
-use Countable;
+use InvalidArgumentException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use InvalidArgumentException;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\View\Engines\EngineResolver;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\View\Factory as FactoryContract;
-use Wpb\String_Blade_Compiler\Engines\CompilerEngine;
+use Illuminate\View\ViewName;
+use Illuminate\View\Engines\EngineResolver;
 use Wpb\String_Blade_Compiler\StringView;
-use Wpb\String_Blade_Compiler\Compilers\StringBladeCompiler;
-
 
 class Factory implements FactoryContract
 {
+    use \Illuminate\View\Concerns\ManagesComponents,
+        \Illuminate\View\Concerns\ManagesEvents,
+        \Illuminate\View\Concerns\ManagesLayouts,
+        \Illuminate\View\Concerns\ManagesLoops,
+        \Illuminate\View\Concerns\ManagesStacks,
+        \Illuminate\View\Concerns\ManagesTranslations;
+
     /**
      * The engine implementation.
      *
@@ -55,25 +58,15 @@ class Factory implements FactoryContract
     protected $shared = [];
 
     /**
-     * Array of registered view name aliases.
-     *
-     * @var array
-     */
-    protected $aliases = [];
-
-    /**
-     * All of the registered view names.
-     *
-     * @var array
-     */
-    protected $names = [];
-
-    /**
      * The extension to engine bindings.
      *
      * @var array
      */
-    protected $extensions = ['blade.php' => 'blade', 'php' => 'php'];
+    protected $extensions = [
+        'blade.php' => 'blade',
+        'php' => 'php',
+        'css' => 'file',
+    ];
 
     /**
      * The view composer events.
@@ -81,41 +74,6 @@ class Factory implements FactoryContract
      * @var array
      */
     protected $composers = [];
-
-    /**
-     * All of the finished, captured sections.
-     *
-     * @var array
-     */
-    protected $sections = [];
-
-    /**
-     * The stack of in-progress sections.
-     *
-     * @var array
-     */
-    protected $sectionStack = [];
-
-    /**
-     * The stack of in-progress loops.
-     *
-     * @var array
-     */
-    protected $loopsStack = [];
-
-    /**
-     * All of the finished, captured push sections.
-     *
-     * @var array
-     */
-    protected $pushes = [];
-
-    /**
-     * The stack of in-progress push sections.
-     *
-     * @var array
-     */
-    protected $pushStack = [];
 
     /**
      * The number of active rendering operations.
@@ -153,132 +111,53 @@ class Factory implements FactoryContract
     {
         $data = array_merge($mergeData, $this->parseData($data));
 
-        $this->callCreator($view = new View($this, $this->getEngineFromPath($path), $path, $path, $data));
-
-        return $view;
+        return tap($this->viewInstance($path, $path, $data), function ($view) {
+            $this->callCreator($view);
+        });
     }
 
     /**
      * Get the evaluated view contents for the given view.
      *
-     * @param  string  $view
+     * @param  string|array  $view
      * @param  array   $data
      * @param  array   $mergeData
-     * @return \Illuminate\View\View|\Wpb\String_Blade_Compiler\StringView
+     * @return \Illuminate\Contracts\View\View|\Wpb\String_Blade_Compiler\StringView
      */
     public function make($view, $data = [], $mergeData = [])
     {
+        $data = array_merge($mergeData, $this->parseData($data));
+
+        // For string rendering
         if (is_array($view)) {
-
-            //$cache =  config('view.compiled');
-            //$compiler = new StringBladeCompiler(app('files'), $cache);
-            //$engine = new CompilerEngine($compiler);
-
-            $engine = $this->engines->resolve('stringblade');
-
-            $data = array_merge($mergeData, $this->parseData($data));
-
-            $this->callCreator($view = new StringView($this, $engine, $view, 'not-used', $data));
-
-        } else {
-
-            if (isset($this->aliases[$view])) {
-                $view = $this->aliases[$view];
-            }
-
-            $view = $this->normalizeName($view);
-
-            $path = $this->finder->find($view);
-
-            $data = array_merge($mergeData, $this->parseData($data));
-
-            $this->callCreator($view = new View($this, $this->getEngineFromPath($path), $view, $path, $data));
-        }
-        return $view;
-    }
-
-    /**
-     * Normalize a view name.
-     *
-     * @param  string $name
-     *
-     * @return string
-     */
-    protected function normalizeName($name)
-    {
-        $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
-
-        if (strpos($name, $delimiter) === false) {
-            return str_replace('/', '.', $name);
+            return $this->makeStringView($view, $data);
         }
 
-        list($namespace, $name) = explode($delimiter, $name);
+        $path = $this->finder->find(
+            $view = $this->normalizeName($view)
+        );
 
-        return $namespace.$delimiter.str_replace('/', '.', $name);
+        // Next, we will create the view instance and call the view creator for the view
+        // which can set any data, etc. Then we will return the view instance back to
+        // the caller for rendering or performing other view manipulations on this.
+
+        return tap($this->viewInstance($view, $path, $data), function ($view) {
+            $this->callCreator($view);
+        });
     }
 
     /**
-     * Parse the given data into a raw array.
+     * Get the evaluated string view contents.
      *
-     * @param  mixed  $data
-     * @return array
+     * @param  array  $view
+     * @param  array   $data
+     * @return \Wpb\String_Blade_Compiler\StringView
      */
-    protected function parseData($data)
+    protected function makeStringView(array $view, $data=[])
     {
-        return $data instanceof Arrayable ? $data->toArray() : $data;
-    }
-
-    /**
-     * Get the evaluated view contents for a named view.
-     *
-     * @param  string  $view
-     * @param  mixed   $data
-     * @return \Illuminate\View\View
-     */
-    public function of($view, $data = [])
-    {
-        return $this->make($this->names[$view], $data);
-    }
-
-    /**
-     * Register a named view.
-     *
-     * @param  string  $view
-     * @param  string  $name
-     * @return void
-     */
-    public function name($view, $name)
-    {
-        $this->names[$name] = $view;
-    }
-
-    /**
-     * Add an alias for a view.
-     *
-     * @param  string  $view
-     * @param  string  $alias
-     * @return void
-     */
-    public function alias($view, $alias)
-    {
-        $this->aliases[$alias] = $view;
-    }
-
-    /**
-     * Determine if a given view exists.
-     *
-     * @param  string  $view
-     * @return bool
-     */
-    public function exists($view)
-    {
-        try {
-            $this->finder->find($view);
-        } catch (InvalidArgumentException $e) {
-            return false;
-        }
-
-        return true;
+        return tap($this->stringViewInstance($view, $data), function ($view) {
+                $this->callCreator($view);
+        });
     }
 
     /**
@@ -299,9 +178,9 @@ class Factory implements FactoryContract
         // iterated value of this data array, allowing the views to access them.
         if (count($data) > 0) {
             foreach ($data as $key => $value) {
-                $data = ['key' => $key, $iterator => $value];
-
-                $result .= $this->make($view, $data)->render();
+                $result .= $this->make(
+                    $view, ['key' => $key, $iterator => $value]
+                )->render();
             }
         }
 
@@ -309,14 +188,76 @@ class Factory implements FactoryContract
         // view. Alternatively, the "empty view" could be a raw string that begins
         // with "raw|" for convenience and to let this know that it is a string.
         else {
-            if (Str::startsWith($empty, 'raw|')) {
-                $result = substr($empty, 4);
-            } else {
-                $result = $this->make($empty)->render();
-            }
+            $result = Str::startsWith($empty, 'raw|')
+                        ? substr($empty, 4)
+                        : $this->make($empty)->render();
         }
 
         return $result;
+    }
+
+    /**
+     * Normalize a view name.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function normalizeName($name)
+    {
+        return ViewName::normalize($name);
+    }
+
+    /**
+     * Parse the given data into a raw array.
+     *
+     * @param  mixed  $data
+     * @return array
+     */
+    protected function parseData($data)
+    {
+        return $data instanceof Arrayable ? $data->toArray() : $data;
+    }
+
+    /**
+     * Create a new view instance from the given arguments.
+     *
+     * @param  string  $view
+     * @param  string  $path
+     * @param  array  $data
+     * @return \Illuminate\Contracts\View\View
+     */
+    protected function viewInstance($view, $path, $data)
+    {
+        return new View($this, $this->getEngineFromPath($path), $view, $path, $data);
+    }
+
+    /**
+     * Create a new string view instance from the given arguments.
+     *
+     * @param  string  $view
+     * @param  array  $data
+     * @return \Wpb\String_Blade_Compiler\StringView
+     */
+    protected function stringViewInstance($view, $data)
+    {
+        return new StringView($this, $this->engines->resolve('stringblade'), $view, 'not-used', $data);
+    }
+
+    /**
+     * Determine if a given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function exists($view)
+    {
+        try {
+            $this->finder->find($view);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -329,7 +270,7 @@ class Factory implements FactoryContract
      */
     public function getEngineFromPath($path)
     {
-        if (!$extension = $this->getExtension($path)) {
+        if (! $extension = $this->getExtension($path)) {
             throw new InvalidArgumentException("Unrecognized extension in file: $path");
         }
 
@@ -375,419 +316,13 @@ class Factory implements FactoryContract
      */
     public function share($key, $value = null)
     {
-        if (!is_array($key)) {
-            return $this->shared[$key] = $value;
+        $keys = is_array($key) ? $key : [$key => $value];
+
+        foreach ($keys as $key => $value) {
+            $this->shared[$key] = $value;
         }
 
-        foreach ($key as $innerKey => $innerValue) {
-            $this->share($innerKey, $innerValue);
-        }
-    }
-
-    /**
-     * Register a view creator event.
-     *
-     * @param  array|string     $views
-     * @param  \Closure|string  $callback
-     * @return array
-     */
-    public function creator($views, $callback)
-    {
-        $creators = [];
-
-        foreach ((array) $views as $view) {
-            $creators[] = $this->addViewEvent($view, $callback, 'creating: ');
-        }
-
-        return $creators;
-    }
-
-    /**
-     * Register multiple view composers via an array.
-     *
-     * @param  array  $composers
-     * @return array
-     */
-    public function composers(array $composers)
-    {
-        $registered = [];
-
-        foreach ($composers as $callback => $views) {
-            $registered = array_merge($registered, $this->composer($views, $callback));
-        }
-
-        return $registered;
-    }
-
-    /**
-     * Register a view composer event.
-     *
-     * @param  array|string  $views
-     * @param  \Closure|string  $callback
-     * @param  int|null  $priority
-     * @return array
-     */
-    public function composer($views, $callback, $priority = null)
-    {
-        $composers = [];
-
-        foreach ((array) $views as $view) {
-            $composers[] = $this->addViewEvent($view, $callback, 'composing: ', $priority);
-        }
-
-        return $composers;
-    }
-
-    /**
-     * Add an event for a given view.
-     *
-     * @param  string  $view
-     * @param  \Closure|string  $callback
-     * @param  string  $prefix
-     * @param  int|null  $priority
-     * @return \Closure|null
-     */
-    protected function addViewEvent($view, $callback, $prefix = 'composing: ', $priority = null)
-    {
-        $view = $this->normalizeName($view);
-
-        if ($callback instanceof Closure) {
-            $this->addEventListener($prefix.$view, $callback, $priority);
-
-            return $callback;
-        } elseif (is_string($callback)) {
-            return $this->addClassEvent($view, $callback, $prefix, $priority);
-        }
-    }
-
-    /**
-     * Register a class based view composer.
-     *
-     * @param  string    $view
-     * @param  string    $class
-     * @param  string    $prefix
-     * @param  int|null  $priority
-     * @return \Closure
-     */
-    protected function addClassEvent($view, $class, $prefix, $priority = null)
-    {
-        $name = $prefix.$view;
-
-        // When registering a class based view "composer", we will simply resolve the
-        // classes from the application IoC container then call the compose method
-        // on the instance. This allows for convenient, testable view composers.
-        $callback = $this->buildClassEventCallback($class, $prefix);
-
-        $this->addEventListener($name, $callback, $priority);
-
-        return $callback;
-    }
-
-    /**
-     * Add a listener to the event dispatcher.
-     *
-     * @param  string    $name
-     * @param  \Closure  $callback
-     * @param  int|null  $priority
-     * @return void
-     */
-    protected function addEventListener($name, $callback, $priority = null)
-    {
-        if (is_null($priority)) {
-            $this->events->listen($name, $callback);
-        } else {
-            $this->events->listen($name, $callback, $priority);
-        }
-    }
-
-    /**
-     * Build a class based container callback Closure.
-     *
-     * @param  string  $class
-     * @param  string  $prefix
-     * @return \Closure
-     */
-    protected function buildClassEventCallback($class, $prefix)
-    {
-        list($class, $method) = $this->parseClassEvent($class, $prefix);
-
-        // Once we have the class and method name, we can build the Closure to resolve
-        // the instance out of the IoC container and call the method on it with the
-        // given arguments that are passed to the Closure as the composer's data.
-        return function () use ($class, $method) {
-            $callable = [$this->container->make($class), $method];
-
-            return call_user_func_array($callable, func_get_args());
-        };
-    }
-
-    /**
-     * Parse a class based composer name.
-     *
-     * @param  string  $class
-     * @param  string  $prefix
-     * @return array
-     */
-    protected function parseClassEvent($class, $prefix)
-    {
-        if (Str::contains($class, '@')) {
-            return explode('@', $class);
-        }
-
-        $method = Str::contains($prefix, 'composing') ? 'compose' : 'create';
-
-        return [$class, $method];
-    }
-
-    /**
-     * Call the composer for a given view.
-     *
-     * @param  \Illuminate\View\View  $view
-     * @return void
-     */
-    public function callComposer(View $view)
-    {
-        $this->events->fire('composing: '.$view->getName(), [$view]);
-    }
-
-    /**
-     * Call the creator for a given view.
-     *
-     * @param  \Illuminate\View\View  $view
-     * @return void
-     */
-    public function callCreator(View $view)
-    {
-        $this->events->fire('creating: '.$view->getName(), [$view]);
-    }
-
-    /**
-     * Start injecting content into a section.
-     *
-     * @param  string  $section
-     * @param  string  $content
-     * @return void
-     */
-    public function startSection($section, $content = '')
-    {
-        if ($content === '') {
-            if (ob_start()) {
-                $this->sectionStack[] = $section;
-            }
-        } else {
-            $this->extendSection($section, $content);
-        }
-    }
-
-    /**
-     * Inject inline content into a section.
-     *
-     * @param  string  $section
-     * @param  string  $content
-     * @return void
-     */
-    public function inject($section, $content)
-    {
-        return $this->startSection($section, $content);
-    }
-
-    /**
-     * Stop injecting content into a section and return its contents.
-     *
-     * @return string
-     */
-    public function yieldSection()
-    {
-        if (empty($this->sectionStack)) {
-            return '';
-        }
-
-        return $this->yieldContent($this->stopSection());
-    }
-
-    /**
-     * Stop injecting content into a section.
-     *
-     * @param  bool  $overwrite
-     * @return string
-     * @throws \InvalidArgumentException
-     */
-    public function stopSection($overwrite = false)
-    {
-        if (empty($this->sectionStack)) {
-            throw new InvalidArgumentException('Cannot end a section without first starting one.');
-        }
-
-        $last = array_pop($this->sectionStack);
-
-        if ($overwrite) {
-            $this->sections[$last] = ob_get_clean();
-        } else {
-            $this->extendSection($last, ob_get_clean());
-        }
-
-        return $last;
-    }
-
-    /**
-     * Stop injecting content into a section and append it.
-     *
-     * @return string
-     * @throws \InvalidArgumentException
-     */
-    public function appendSection()
-    {
-        if (empty($this->sectionStack)) {
-            throw new InvalidArgumentException('Cannot end a section without first starting one.');
-        }
-
-        $last = array_pop($this->sectionStack);
-
-        if (isset($this->sections[$last])) {
-            $this->sections[$last] .= ob_get_clean();
-        } else {
-            $this->sections[$last] = ob_get_clean();
-        }
-
-        return $last;
-    }
-
-    /**
-     * Append content to a given section.
-     *
-     * @param  string  $section
-     * @param  string  $content
-     * @return void
-     */
-    protected function extendSection($section, $content)
-    {
-        if (isset($this->sections[$section])) {
-            $content = str_replace('@parent', $content, $this->sections[$section]);
-        }
-
-        $this->sections[$section] = $content;
-    }
-
-    /**
-     * Get the string contents of a section.
-     *
-     * @param  string  $section
-     * @param  string  $default
-     * @return string
-     */
-    public function yieldContent($section, $default = '')
-    {
-        $sectionContent = $default;
-
-        if (isset($this->sections[$section])) {
-            $sectionContent = $this->sections[$section];
-        }
-
-        $sectionContent = str_replace('@@parent', '--parent--holder--', $sectionContent);
-
-        return str_replace(
-            '--parent--holder--', '@parent', str_replace('@parent', '', $sectionContent)
-        );
-    }
-
-    /**
-     * Start injecting content into a push section.
-     *
-     * @param  string  $section
-     * @param  string  $content
-     * @return void
-     */
-    public function startPush($section, $content = '')
-    {
-        if ($content === '') {
-            if (ob_start()) {
-                $this->pushStack[] = $section;
-            }
-        } else {
-            $this->extendPush($section, $content);
-        }
-    }
-
-    /**
-     * Stop injecting content into a push section.
-     *
-     * @return string
-     * @throws \InvalidArgumentException
-     */
-    public function stopPush()
-    {
-        if (empty($this->pushStack)) {
-            throw new InvalidArgumentException('Cannot end a section without first starting one.');
-        }
-
-        $last = array_pop($this->pushStack);
-
-        $this->extendPush($last, ob_get_clean());
-
-        return $last;
-    }
-
-    /**
-     * Append content to a given push section.
-     *
-     * @param  string  $section
-     * @param  string  $content
-     * @return void
-     */
-    protected function extendPush($section, $content)
-    {
-        if (! isset($this->pushes[$section])) {
-            $this->pushes[$section] = [];
-        }
-        if (! isset($this->pushes[$section][$this->renderCount])) {
-            $this->pushes[$section][$this->renderCount] = $content;
-        } else {
-            $this->pushes[$section][$this->renderCount] .= $content;
-        }
-    }
-
-    /**
-     * Get the string contents of a push section.
-     *
-     * @param  string  $section
-     * @param  string  $default
-     * @return string
-     */
-    public function yieldPushContent($section, $default = '')
-    {
-        if (! isset($this->pushes[$section])) {
-            return $default;
-        }
-
-        return implode(array_reverse($this->pushes[$section]));
-    }
-
-    /**
-     * Flush all of the section contents.
-     *
-     * @return void
-     */
-    public function flushSections()
-    {
-        $this->renderCount = 0;
-
-        $this->sections = [];
-        $this->sectionStack = [];
-
-        $this->pushes = [];
-        $this->pushStack = [];
-    }
-
-    /**
-     * Flush all of the section contents if done rendering.
-     *
-     * @return void
-     */
-    public function flushSectionsIfDoneRendering()
-    {
-        if ($this->doneRendering()) {
-            $this->flushSections();
-        }
+        return $value;
     }
 
     /**
@@ -821,81 +356,6 @@ class Factory implements FactoryContract
     }
 
     /**
-     * Add new loop to the stack.
-     *
-     * @param  array|\Countable  $data
-     * @return void
-     */
-    public function addLoop($data)
-    {
-        $length = is_array($data) || $data instanceof Countable ? count($data) : null;
-
-        $parent = Arr::last($this->loopsStack);
-
-        $this->loopsStack[] = [
-            'iteration' => 0,
-            'index' => 0,
-            'remaining' => isset($length) ? $length : null,
-            'count' => $length,
-            'first' => true,
-            'last' => isset($length) ? $length == 1 : null,
-            'depth' => count($this->loopsStack) + 1,
-            'parent' => $parent ? (object) $parent : null,
-        ];
-    }
-
-    /**
-     * Increment the top loop's indices.
-     *
-     * @return void
-     */
-    public function incrementLoopIndices()
-    {
-        $loop = &$this->loopsStack[count($this->loopsStack) - 1];
-
-        $loop['iteration']++;
-        $loop['index'] = $loop['iteration'] - 1;
-
-        $loop['first'] = $loop['iteration'] == 1;
-
-        if (isset($loop['count'])) {
-            $loop['remaining']--;
-
-            $loop['last'] = $loop['iteration'] == $loop['count'];
-        }
-    }
-
-    /**
-     * Pop a loop from the top of the loop stack.
-     *
-     * @return void
-     */
-    public function popLoop()
-    {
-        array_pop($this->loopsStack);
-    }
-
-    /**
-     * Get an instance of the first loop in the stack.
-     *
-     * @return array
-     */
-    public function getFirstLoop()
-    {
-        return ($last = Arr::last($this->loopsStack)) ? (object) $last : null;
-    }
-
-    /**
-     * Get the entire loop stack.
-     *
-     * @return array
-     */
-    public function getLoopStack()
-    {
-        return $this->loopsStack;
-    }
-
-    /**
      * Add a location to the array of view locations.
      *
      * @param  string  $location
@@ -911,11 +371,13 @@ class Factory implements FactoryContract
      *
      * @param  string  $namespace
      * @param  string|array  $hints
-     * @return void
+     * @return $this
      */
     public function addNamespace($namespace, $hints)
     {
         $this->finder->addNamespace($namespace, $hints);
+
+        return $this;
     }
 
     /**
@@ -923,11 +385,13 @@ class Factory implements FactoryContract
      *
      * @param  string  $namespace
      * @param  string|array  $hints
-     * @return void
+     * @return $this
      */
     public function prependNamespace($namespace, $hints)
     {
         $this->finder->prependNamespace($namespace, $hints);
+
+        return $this;
     }
 
     /**
@@ -935,11 +399,13 @@ class Factory implements FactoryContract
      *
      * @param  string  $namespace
      * @param  string|array  $hints
-     * @return void
+     * @return $this
      */
     public function replaceNamespace($namespace, $hints)
     {
         $this->finder->replaceNamespace($namespace, $hints);
+
+        return $this;
     }
 
     /**
@@ -1030,6 +496,16 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Flush the cache of views located by the finder.
+     *
+     * @return void
+     */
+    public function flushFinderCache()
+    {
+        $this->getFinder()->flush();
+    }
+
+    /**
      * Get the event dispatcher instance.
      *
      * @return \Illuminate\Contracts\Events\Dispatcher
@@ -1091,36 +567,5 @@ class Factory implements FactoryContract
     public function getShared()
     {
         return $this->shared;
-    }
-
-    /**
-     * Check if section exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function hasSection($name)
-    {
-        return array_key_exists($name, $this->sections);
-    }
-
-    /**
-     * Get the entire array of sections.
-     *
-     * @return array
-     */
-    public function getSections()
-    {
-        return $this->sections;
-    }
-
-    /**
-     * Get all of the registered named views in environment.
-     *
-     * @return array
-     */
-    public function getNames()
-    {
-        return $this->names;
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -931,6 +931,18 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Replace the namespace hints for the given namespace.
+     *
+     * @param  string  $namespace
+     * @param  string|array  $hints
+     * @return void
+     */
+    public function replaceNamespace($namespace, $hints)
+    {
+        $this->finder->replaceNamespace($namespace, $hints);
+    }
+
+    /**
      * Register a valid view extension and its engine.
      *
      * @param  string    $extension

--- a/src/FileViewFinder.php
+++ b/src/FileViewFinder.php
@@ -40,7 +40,7 @@ class FileViewFinder implements ViewFinderInterface
      *
      * @var array
      */
-    protected $extensions = ['blade.php', 'php'];
+    protected $extensions = ['blade.php', 'php', 'css'];
 
     /**
      * Create a new file view loader instance.
@@ -152,6 +152,17 @@ class FileViewFinder implements ViewFinderInterface
     }
 
     /**
+     * Prepend a location to the finder.
+     *
+     * @param  string  $location
+     * @return void
+     */
+    public function prependLocation($location)
+    {
+        array_unshift($this->paths, $location);
+    }
+
+    /**
      * Add a location to the finder.
      *
      * @param  string  $location
@@ -234,6 +245,16 @@ class FileViewFinder implements ViewFinderInterface
     public function hasHintInformation($name)
     {
         return strpos($name, static::HINT_PATH_DELIMITER) > 0;
+    }
+
+    /**
+     * Flush the cache of located views.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->views = [];
     }
 
     /**

--- a/src/FileViewFinder.php
+++ b/src/FileViewFinder.php
@@ -181,6 +181,18 @@ class FileViewFinder implements ViewFinderInterface
     }
 
     /**
+     * Replace the namespace hints for the given namespace.
+     *
+     * @param  string  $namespace
+     * @param  string|array  $hints
+     * @return void
+     */
+    public function replaceNamespace($namespace, $hints)
+    {
+        $this->hints[$namespace] = (array) $hints;
+    }
+
+    /**
      * Prepend a namespace hint to the finder.
      *
      * @param  string  $namespace

--- a/src/ViewFinderInterface.php
+++ b/src/ViewFinderInterface.php
@@ -46,6 +46,15 @@ interface ViewFinderInterface
     public function prependNamespace($namespace, $hints);
 
     /**
+     * Replace the namespace hints for the given namespace.
+     *
+     * @param  string  $namespace
+     * @param  string|array  $hints
+     * @return $this
+     */
+    public function replaceNamespace($namespace, $hints);
+
+    /**
      * Add a valid view extension to the finder.
      *
      * @param  string  $extension

--- a/src/ViewServiceProvider.php
+++ b/src/ViewServiceProvider.php
@@ -3,9 +3,10 @@
 namespace Wpb\String_Blade_Compiler;
 
 use Illuminate\View\Engines\EngineResolver;
-use Wpb\String_Blade_Compiler\Engines\CompilerEngine;
+use Illuminate\View\Engines\FileEngine;
 use Wpb\String_Blade_Compiler\Compilers\BladeCompiler;
 use Wpb\String_Blade_Compiler\Compilers\StringBladeCompiler;
+use Wpb\String_Blade_Compiler\Engines\CompilerEngine;
 
 class ViewServiceProvider extends \Illuminate\View\ViewServiceProvider
 {
@@ -46,11 +47,24 @@ class ViewServiceProvider extends \Illuminate\View\ViewServiceProvider
             // Next we will register the various engines with the resolver so that the
             // environment can resolve the engines it needs for various views based
             // on the extension of view files. We call a method for each engines.
-            foreach (['php', 'blade', 'StringBlade'] as $engine) {
+            foreach (['file', 'php', 'blade', 'StringBlade'] as $engine) {
                 $this->{'register'.ucfirst($engine).'Engine'}($resolver);
             }
 
             return $resolver;
+        });
+    }
+
+    /**
+     * Register the file engine implementation.
+     *
+     * @param  \Illuminate\View\Engines\EngineResolver  $resolver
+     * @return void
+     */
+    public function registerFileEngine($resolver)
+    {
+        $resolver->register('file', function () {
+            return new FileEngine;
         });
     }
 


### PR DESCRIPTION
Breaks tests which need updating (many due to using app('translator')->get() rather than the Lang::get() facade), but updates to Laravel's recent changes and brings 5.4 compatibility.

I guess this will need putting in a 3.4 branch?