### PR TITLE
Add first function to Factory

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\View\ViewName;
 use Illuminate\View\Engines\EngineResolver;
-use Wpb\String_Blade_Compiler\StringView;
 
 class Factory implements FactoryContract
 {
@@ -158,6 +157,27 @@ class Factory implements FactoryContract
         return tap($this->stringViewInstance($view, $data), function ($view) {
                 $this->callCreator($view);
         });
+    }
+
+    /**
+     * Get the first view that actually exists from the given list.
+     *
+     * @param  array  $views
+     * @param  array   $data
+     * @param  array   $mergeData
+     * @return \Illuminate\Contracts\View\View|\Wpb\String_Blade_Compiler\StringView
+     */
+    public function first(array $views, $data = [], $mergeData = [])
+    {
+        $view = collect($views)->first(function ($view) {
+            return $this->exists($view);
+        });
+
+        if (! $view) {
+            throw new InvalidArgumentException('None of the views in the given array exist.');
+        }
+
+        return $this->make($view, $data, $mergeData);
     }
 
     /**


### PR DESCRIPTION
Laravel 5.5 added the first function to the View Factory (See https://github.com/laravel/framework/commit/5dcf584865cceef9f9690673d6a6bd6241e3834a and https://github.com/laravel/framework/commit/f18318b35b246a7f279781fe7403d137fb55be05).
This PR adds first to the StringBladeCompiler Factory as well.

I have added the tests which were added in the Laravel Framework version as well, but was not able to test them.