### PR TITLE
Fix Laravel 6 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel/framework": "6.0.*"
+        "laravel/framework": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The version specification prevents the package to be installed on latest Laravel versions. Laravel uses semver now. This PR fixes this.

Fixes #54  