### PR TITLE
Laravel 7 and autoload blade custom directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.netbeans/
 /bkp/
+vendor/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ In config\app.php, providers section:
 Config
 =======================
 
-Default cache time for the compiled string template is 300 seconds (5 mins), this can be changed in the config file or when calling a view. The change is global to all string templates.
+Default cache time for the compiled string template is 300 seconds (5 mins), this can be changed in the config file, env file, or when calling a view. The change is global to all string templates.
+
+`STRING_BLADE_CACHE_TIMEOUT=300`
+
+Autoloading of blade custom directives can be changed in the config and env files.
+
+`STRING_BLADE_AUTOLOAD=false`
 
 Note: If using homestead or some other vm, the host handles the filemtime of the cache file. This means the vm may have a different time than the file. If the cache is not expiring as expected, check the times between the systems.
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/blade.php
+++ b/config/blade.php
@@ -4,6 +4,8 @@ return [
     // How many seconds past compiled file last modified time to recompile the template
     // A value of 0 is always recompile
     // Note: homestead time verses pc time may be off
-    'secondsTemplateCacheExpires' => 300
+    'secondsTemplateCacheExpires' =>  env('STRING_BLADE_CACHE_TIMEOUT', 300),
 
+    // Determine whether the service provider to autoload blade custom directives.
+    'autoload_custom_directives' => env('STRING_BLADE_AUTOLOAD', false),
 ];

--- a/src/Compilers/StringBladeCompiler.php
+++ b/src/Compilers/StringBladeCompiler.php
@@ -132,5 +132,4 @@ class StringBladeCompiler extends BladeCompiler {
 
         return time() >= ($this->files->lastModified($compiled) + $viewData->secondsTemplateCacheExpires) ;
     }
-
 }


### PR DESCRIPTION
- Updated for Laravel 7
- Can now autoload Balde custom directives:
  - Added an option to the config to autoload custom directives.
  - Added env variables to config.
  - Updated README.
  - Deferred StringBladeServiceProvider.
  - Added `vendor/` to .gitignore.