### PR TITLE
Fix of BindingResolutionException

### DIFF
--- a/src/StringBladeServiceProvider.php
+++ b/src/StringBladeServiceProvider.php
@@ -26,6 +26,7 @@ class StringBladeServiceProvider extends ViewServiceProvider
         $this->registerViewFinder();
         $this->registerBladeCompiler();
         $this->registerEngineResolver();
+        $this->registerStringBladeEngine($this->app['view.engine.resolver']);
 
     }
 


### PR DESCRIPTION
Fix of `BindingResolutionException: Target class [stringblade.compiler] does not exist.`
Appears for Laravel v6.18.41 and StringBladeCompiler v6.0.2
After correct service override an error appears.
This fix resolves issue described above.
Full log data for this exception attached to message.

[laravel.log](https://github.com/TerrePorter/StringBladeCompiler/files/5319178/laravel.log)
