### PR TITLE
Update phpdoc

### DIFF
--- a/src/Facades/StringBlade.php
+++ b/src/Facades/StringBlade.php
@@ -8,7 +8,7 @@ use Wpb\String_Blade_Compiler\Compilers\StringBladeCompiler;
 /**
  * @method static bool exists(string $view)
  * @method static \Illuminate\Contracts\View\View file(string $path, array $data = [], array $mergeData = [])
- * @method static \Illuminate\Contracts\View\View make(string $view, array $data = [], array $mergeData = [])
+ * @method static \Wpb\String_Blade_Compiler\StringView make(string|array $view, array $data = [], array $mergeData = [])
  * @method static mixed share(array|string $key, $value = null)
  * @method static array composer(array|string $views, \Closure|string $callback)
  * @method static array creator(array|string $views, \Closure|string $callback)


### PR DESCRIPTION
I guess this is not 100% right since it can return `\Illuminate\Contracts\View\View` also, however that doesn't play well with PHPStan.

Now this works without errors in phpstan;
```php
use Wpb\String_Blade_Compiler\Facades\StringBlade as View;

return View::make(['template' => $data['template']->template], $alert)->__toString();
``` 